### PR TITLE
Fix multi ssh user support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Laravel Forge Changelog
 
+## [Fix] - 2023-05-12
+- Fixes bug in displaying the ssh:// protocol string
 ## [Fix] - 2023-05-04
 
 - Fixes a bug in the launch command invocation.

--- a/src/api/Server.ts
+++ b/src/api/Server.ts
@@ -24,12 +24,14 @@ export const Server = {
     let servers = await getServers({
       tokenKey: "laravel_forge_api_key",
       token: preferences?.laravel_forge_api_key as string,
+      sshUser: (preferences?.laravel_forge_ssh_user as string) || "forge",
     });
 
     if (preferences?.laravel_forge_api_key_two) {
       const serversTwo = await getServers({
         tokenKey: "laravel_forge_api_key_two",
         token: preferences?.laravel_forge_api_key_two as string,
+        sshUser: (preferences?.laravel_forge_ssh_user_two as string) || "forge",
       });
       servers = [...servers, ...serversTwo];
     }
@@ -45,7 +47,7 @@ export const Server = {
   },
 };
 
-const getServers = async ({ token, tokenKey }: { token: string; tokenKey: string }) => {
+const getServers = async ({ token, tokenKey, sshUser }: { token: string; tokenKey: string; sshUser: string }) => {
   const { servers } = await apiFetch<{ servers: IServer[] }>(`${FORGE_API_URL}/servers`, {
     method: "get",
     headers: { ...defaultHeaders, Authorization: `Bearer ${token}` },
@@ -65,6 +67,7 @@ const getServers = async ({ token, tokenKey }: { token: string; tokenKey: string
     .map((server) => {
       server.keywords = server?.id && keywordsByServer[server.id] ? [...keywordsByServer[server.id]] : [];
       server.api_token_key = tokenKey;
+      server.ssh_user = sshUser;
       return server;
     })
     .filter((s) => !s.revoked);

--- a/src/components/actions/ServerCommands.tsx
+++ b/src/components/actions/ServerCommands.tsx
@@ -1,12 +1,10 @@
-import { Icon, Action, getPreferenceValues, showToast, LocalStorage, Toast } from "@raycast/api";
+import { Icon, Action, showToast, LocalStorage, Toast } from "@raycast/api";
 import { Server } from "../../api/Server";
 import { IServer } from "../../types";
 import { clearCache } from "../../lib/cache";
 import { unwrapToken } from "../../lib/auth";
 
 export const ServerCommands = ({ server }: { server: IServer }) => {
-  const preferences = getPreferenceValues();
-  const sshUser = preferences?.laravel_forge_ssh_user ?? "forge";
   const token = unwrapToken(server.api_token_key);
   return (
     <>
@@ -14,8 +12,8 @@ export const ServerCommands = ({ server }: { server: IServer }) => {
       <Action.OpenInBrowser
         icon={Icon.Terminal}
         // eslint-disable-next-line @raycast/prefer-title-case
-        title={`Open SSH Connection (${sshUser})`}
-        url={`ssh://${sshUser}@${server.ip_address}`}
+        title={`Open SSH Connection (${server.ssh_user})`}
+        url={`ssh://${server.ssh_user}@${server.ip_address}`}
       />
       <Action
         icon={Icon.ArrowClockwise}

--- a/src/components/servers/ServerSingle.tsx
+++ b/src/components/servers/ServerSingle.tsx
@@ -1,12 +1,10 @@
-import { ActionPanel, List, Icon, Action, getPreferenceValues, showToast, Toast } from "@raycast/api";
+import { ActionPanel, List, Icon, Action, showToast, Toast } from "@raycast/api";
 import { Server } from "../../api/Server";
 import { IServer } from "../../types";
 import { unwrapToken } from "../../lib/auth";
 import { SitesList } from "../sites/SitesList";
 
 export const ServerSingle = ({ server }: { server: IServer }) => {
-  const preferences = getPreferenceValues();
-  const sshUser = preferences?.laravel_forge_ssh_user ?? "forge";
   const token = unwrapToken(server.api_token_key);
 
   return (
@@ -30,15 +28,19 @@ export const ServerSingle = ({ server }: { server: IServer }) => {
         <List.Item
           id="open-in-ssh"
           key="open-in-ssh"
-          title={`Open SSH connection (${sshUser})`}
+          title={`Open SSH connection (${server.ssh_user})`}
           icon={Icon.Terminal}
-          accessories={[{ text: `ssh://${sshUser}@${server.ip_address}` }]}
+          accessories={[{ text: `ssh://${server.ssh_user}@${server.ip_address}` }]}
           actions={
             <ActionPanel>
               <Action.OpenInBrowser
                 // eslint-disable-next-line @raycast/prefer-title-case
-                title={`Open SSH Connection (${sshUser})`}
-                url={`ssh://${sshUser}@${server.ip_address}`}
+                title={`Open SSH Connection (${server.ssh_user})`}
+                url={`ssh://${server.ssh_user}@${server.ip_address}`}
+              />
+              <Action.CopyToClipboard
+                title="Copy SSH Connection String"
+                content={`ssh://${server.ssh_user}@${server.ip_address}`}
               />
             </ActionPanel>
           }

--- a/src/components/sites/SiteSingle.tsx
+++ b/src/components/sites/SiteSingle.tsx
@@ -63,6 +63,10 @@ export const SiteSingle = ({ site, server }: { site: ISite; server: IServer }) =
                   title={`Open SSH Connection (${site.username})`}
                   url={`ssh://${site.username}@${server.ip_address}`}
                 />
+                <Action.CopyToClipboard
+                  title="Copy SSH Connection String"
+                  content={`ssh://${site.username}@${server.ip_address}`}
+                />
               </ActionPanel>
             }
           />

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface IServer {
   api_token_key: string;
+  ssh_user: string;
   id: number;
   credential_id?: string | null;
   name?: string;


### PR DESCRIPTION
This fixes a bug where multiple accounts would use the same ssh user for both (only on ssh:// links).

Also adds an option to copy the protocol string to the clipboard

Closes #24 