### PR TITLE
Ask Laravel Forge from AI Chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Laravel Forge Changelog
 
-## [Forge API v2] - {PR_MERGE_DATE}
+## [Forge API v2 and AI Tools] - {PR_MERGE_DATE}
+- Ask Laravel Forge from AI Chat: what is deploying, why a deploy failed, a site's Nginx config or logs, whether a site is up
+- Deploying a site, restarting a service and rebooting a server are AI tools too, each asking to confirm first and listing the sites it affects
 - Move every request to the Forge API v2, which replaces v1 on August 31, 2026
 - Servers are now listed per organization, across all organizations a token can see
 - Asks for a new API token, since v2 tokens are scoped — see the README for which scopes to tick

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Laravel Forge Changelog
 
-## [Forge API v2 and AI Tools] - {PR_MERGE_DATE}
+## [AI Tools] - {PR_MERGE_DATE}
 - Ask Laravel Forge from AI Chat: what is deploying, why a deploy failed, a site's Nginx config or logs, whether a site is up
 - Deploying a site, restarting a service and rebooting a server are AI tools too, each asking to confirm first and listing the sites it affects
+
+## [Forge API v2] - 2026-08-18
 - Move every request to the Forge API v2, which replaces v1 on August 31, 2026
 - Servers are now listed per organization, across all organizations a token can see
 - Asks for a new API token, since v2 tokens are scoped — see the README for which scopes to tick

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ rejected the token, it is missing a scope or predates the v2 API.
 - Trigger deploy script
 - Reboot services
 
+## AI Chat
+Once installed, an "Ask Laravel Forge" item appears at the top of root search, and the extension can be
+mentioned from AI Chat or Quick AI. It can list servers and sites, report what is deploying, read a
+deployment log to explain a failure, read a site's Nginx config or logs, and check whether a site
+responds. Deploying a site, restarting a service and rebooting a server ask for confirmation first, and
+the card names every site the action takes down. A site's `.env` is deliberately out of reach here,
+since anything a tool returns is sent to the model.
+
 ## Non-Forge API Features
 - Check site connectivity
 - Open command from raycast:// url

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "@raycast/api": "^1.104.24",
         "date-fns": "^4.4.0",
         "lodash": "^4.17.21",
-        "node-fetch": "^3.3.2",
         "run-applescript": "^7.1.0",
         "swr": "^2.5.1"
       },
@@ -1780,15 +1779,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/date-fns": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
@@ -2182,29 +2172,6 @@
         }
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2291,18 +2258,6 @@
       "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
@@ -2638,44 +2593,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3088,15 +3005,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "type": "password",
       "required": true,
       "title": "Forge API Token (v2)",
-      "description": "Forge API v1 is retired, so this needs a new v2 token. Create one at forge.laravel.com/profile/api \u2014 see the README for the scopes to tick.",
+      "description": "Generate from your Laravel Forge profile",
       "placeholder": "API Token"
     },
     {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,63 @@
       "interval": "10s"
     }
   ],
+  "tools": [
+    {
+      "name": "list-servers",
+      "title": "List Servers",
+      "description": "List every Laravel Forge server across the configured accounts, with provider, region, IP address and connection status"
+    },
+    {
+      "name": "list-sites",
+      "title": "List Sites",
+      "description": "List sites across every server, or only the sites on one named server, with their repository, branch and deployment status"
+    },
+    {
+      "name": "deployment-status",
+      "title": "Check Deployment Status",
+      "description": "Show which sites are deploying right now and which ones have a failed deployment"
+    },
+    {
+      "name": "deployment-history",
+      "title": "Get Deployment History",
+      "description": "List recent deployments for a site with their status, commit and timings"
+    },
+    {
+      "name": "deployment-log",
+      "title": "Read Deployment Log",
+      "description": "Read the output of a site's latest deployment, or of a specific deployment, to find out why it failed"
+    },
+    {
+      "name": "server-events",
+      "title": "Get Server Events",
+      "description": "List recent Forge events for a server, or read the command output of one event"
+    },
+    {
+      "name": "site-online",
+      "title": "Check If a Site Is Online",
+      "description": "Request a site over HTTP and report whether it responds"
+    },
+    {
+      "name": "site-config",
+      "title": "Read Site Config or Logs",
+      "description": "Read a site's nginx config, application log, nginx error log or nginx access log"
+    },
+    {
+      "name": "deploy-site",
+      "title": "Deploy a Site",
+      "description": "Trigger a deployment for a site"
+    },
+    {
+      "name": "restart-service",
+      "title": "Restart a Service",
+      "description": "Start, stop or restart php, nginx, mysql or redis on a server"
+    },
+    {
+      "name": "reboot-server",
+      "title": "Reboot a Server",
+      "description": "Reboot a server, taking every site on it down until it comes back"
+    }
+  ],
   "preferences": [
     {
       "name": "laravel_forge_api_token",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@raycast/api": "^1.104.24",
     "date-fns": "^4.4.0",
     "lodash": "^4.17.21",
-    "node-fetch": "^3.3.2",
     "run-applescript": "^7.1.0",
     "swr": "^2.5.1"
   },

--- a/src/hooks/useIsSiteOnline.ts
+++ b/src/hooks/useIsSiteOnline.ts
@@ -1,6 +1,5 @@
 import useSWR from "swr";
 import { ISite } from "../types";
-import fetch from "node-fetch";
 import { findValidUrlsFromSite } from "../lib/url";
 import { USE_FAKE_DATA } from "../config";
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,4 @@
-import { LaunchType, LocalStorage, Toast, environment, popToRoot, showToast } from "@raycast/api";
-import fetch, { RequestInit } from "node-fetch";
+import { LaunchType, LocalStorage, Toast, captureException, environment, popToRoot, showToast } from "@raycast/api";
 import { clearCache } from "./cache";
 
 const doTheFetch = async (url: string, options?: RequestInit) => {
@@ -10,6 +9,7 @@ const doTheFetch = async (url: string, options?: RequestInit) => {
   } catch (e) {
     if (e instanceof Error) {
       console.error({ error: e, url });
+      captureException(e);
       if (!isBackground) showResetToast({ title: `Error ${res?.status}: ${e.message}` });
       throw new Error(e.message);
     }
@@ -21,6 +21,7 @@ const doTheFetch = async (url: string, options?: RequestInit) => {
       ? "Forge rejected the API token. Create a v2 token with the scopes you need."
       : `Error ${res?.status}: ${res?.statusText}`;
     if (!isBackground) showResetToast({ title });
+    captureException(new Error(`${res?.status} ${res?.statusText}: ${url}`));
     throw new Error(res?.statusText);
   }
   return res;

--- a/src/lib/resolve.ts
+++ b/src/lib/resolve.ts
@@ -1,0 +1,87 @@
+import { Server } from "../api/Server";
+import { Site } from "../api/Site";
+import { IServer, ISite } from "../types";
+import { unwrapToken } from "./auth";
+
+export type ServerMatch = { server: IServer; token: string };
+export type SiteMatch = { site: ISite; server: IServer; token: string };
+
+type Candidate<T> = { entry: T; label: string; score: number };
+
+const normalize = (value: string) => value.trim().toLowerCase();
+
+const score = (name: string | undefined, query: string) => {
+  const target = normalize(name ?? "");
+  const search = normalize(query);
+  if (!target || !search) return 0;
+  if (target === search) return 2;
+  return target.includes(search) ? 1 : 0;
+};
+
+// Errors instead of a best guess, so the model re-asks rather than hitting the wrong server
+const pick = <T>(candidates: Candidate<T>[], query: string, kind: string) => {
+  const best = Math.max(0, ...candidates.map((candidate) => candidate.score));
+  const labels = candidates.map((candidate) => candidate.label).join(", ");
+  if (!best) throw new Error(`No ${kind} matches "${query}". Available ${kind}s: ${labels}`);
+  const winners = candidates.filter((candidate) => candidate.score === best);
+  if (winners.length > 1) {
+    throw new Error(`"${query}" matches several ${kind}s: ${winners.map((w) => w.label).join(", ")}. Ask which one.`);
+  }
+  return winners[0].entry;
+};
+
+export const allServers = async (): Promise<ServerMatch[]> => {
+  const servers = await Server.getAll();
+  return servers.map((server) => ({ server, token: unwrapToken(server.api_token_key) }));
+};
+
+export const findServer = async (query: string) => {
+  const servers = await allServers();
+  return pick(
+    servers.map((entry) => ({
+      entry,
+      label: entry.server.name ?? String(entry.server.id),
+      score: Math.max(score(entry.server.name, query), String(entry.server.id) === normalize(query) ? 2 : 0),
+    })),
+    query,
+    "server",
+  );
+};
+
+export const allSites = async (): Promise<SiteMatch[]> => {
+  const servers = await allServers();
+  const tokenKeys = [...new Set(servers.map(({ server }) => server.api_token_key))];
+  const perAccount = await Promise.all(
+    tokenKeys.map(async (tokenKey) => {
+      const token = unwrapToken(tokenKey);
+      const sites = await Site.getSitesWithoutServer({ token });
+      return sites.flatMap((site) => {
+        // Server ids only mean anything within the account they came from
+        const owner = servers.find(({ server }) => server.api_token_key === tokenKey && server.id === site.server_id);
+        return owner ? [{ site, server: owner.server, token }] : [];
+      });
+    }),
+  );
+  return perAccount.flat();
+};
+
+export const findSite = async (query: string) => {
+  const sites = await allSites();
+  return pick(
+    sites.map((entry) => ({
+      entry,
+      label: entry.site.name ?? String(entry.site.id),
+      score: Math.max(
+        score(entry.site.name, query),
+        String(entry.site.id) === normalize(query) ? 2 : 0,
+        ...(entry.site.aliases ?? []).map((alias) => score(alias, query)),
+      ),
+    })),
+    query,
+    "site",
+  );
+};
+
+// Logs run to megabytes and the whole result is fed to the model
+export const tail = (output: string, limit = 4_000) =>
+  output.length > limit ? `…truncated…\n${output.slice(-limit)}` : output;

--- a/src/tools/deploy-site.ts
+++ b/src/tools/deploy-site.ts
@@ -1,5 +1,6 @@
 import { Tool } from "@raycast/api";
 import { Site } from "../api/Site";
+import { repositoryLabel } from "../lib/url";
 import { findSite } from "./helpers";
 
 type Input = {
@@ -15,7 +16,10 @@ export const confirmation: Tool.Confirmation<Input> = async ({ site }) => {
     message: `Deploy ${found.name}?`,
     info: [
       { name: "Server", value: server.name ?? String(server.id) },
+      { name: "Repository", value: repositoryLabel(found.repository) || "none" },
       { name: "Branch", value: found.repository?.branch ?? "unknown" },
+      { name: "Current status", value: found.deployment_status ?? "idle" },
+      { name: "Quick deploy", value: found.quick_deploy ? "on" : "off" },
     ],
   };
 };

--- a/src/tools/deploy-site.ts
+++ b/src/tools/deploy-site.ts
@@ -1,0 +1,27 @@
+import { Tool } from "@raycast/api";
+import { Site } from "../api/Site";
+import { findSite } from "../lib/resolve";
+
+type Input = {
+  /**
+   * Name of the site to deploy, as shown in Forge (for example "example.com").
+   */
+  site: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async ({ site }) => {
+  const { site: found, server } = await findSite(site);
+  return {
+    message: `Deploy ${found.name}?`,
+    info: [
+      { name: "Server", value: server.name ?? String(server.id) },
+      { name: "Branch", value: found.repository?.branch ?? "unknown" },
+    ],
+  };
+};
+
+export default async function tool({ site }: Input) {
+  const { site: found, server, token } = await findSite(site);
+  await Site.deploy({ orgSlug: server.org_slug, serverId: server.id, siteId: found.id, token });
+  return { site: found.name, server: server.name, started: true };
+}

--- a/src/tools/deploy-site.ts
+++ b/src/tools/deploy-site.ts
@@ -1,6 +1,6 @@
 import { Tool } from "@raycast/api";
 import { Site } from "../api/Site";
-import { findSite } from "../lib/resolve";
+import { findSite } from "./helpers";
 
 type Input = {
   /**

--- a/src/tools/deployment-history.ts
+++ b/src/tools/deployment-history.ts
@@ -1,5 +1,5 @@
 import { Site } from "../api/Site";
-import { findSite } from "../lib/resolve";
+import { findSite } from "./helpers";
 
 type Input = {
   /**

--- a/src/tools/deployment-history.ts
+++ b/src/tools/deployment-history.ts
@@ -1,0 +1,29 @@
+import { Site } from "../api/Site";
+import { findSite } from "../lib/resolve";
+
+type Input = {
+  /**
+   * Name of the site, as shown in Forge (for example "example.com").
+   */
+  site: string;
+};
+
+export default async function tool({ site }: Input) {
+  const { site: found, server, token } = await findSite(site);
+  const deployments = await Site.getDeploymentHistory({
+    orgSlug: server.org_slug,
+    serverId: server.id,
+    siteId: found.id,
+    token,
+  });
+  return deployments.map((deployment) => ({
+    id: deployment.id,
+    status: deployment.status,
+    startedAt: deployment.started_at,
+    endedAt: deployment.ended_at,
+    commit: deployment.commit?.hash,
+    branch: deployment.commit?.branch,
+    message: deployment.commit?.message,
+    author: deployment.commit?.author,
+  }));
+}

--- a/src/tools/deployment-log.ts
+++ b/src/tools/deployment-log.ts
@@ -1,5 +1,5 @@
 import { Site } from "../api/Site";
-import { findSite, tail } from "../lib/resolve";
+import { findSite, tail } from "./helpers";
 
 type Input = {
   /**

--- a/src/tools/deployment-log.ts
+++ b/src/tools/deployment-log.ts
@@ -1,0 +1,28 @@
+import { Site } from "../api/Site";
+import { findSite, tail } from "../lib/resolve";
+
+type Input = {
+  /**
+   * Name of the site, as shown in Forge (for example "example.com").
+   */
+  site: string;
+  /**
+   * Id of a specific deployment. Leave empty for the most recent deployment.
+   */
+  deploymentId?: number;
+};
+
+export default async function tool({ site, deploymentId }: Input) {
+  const { site: found, server, token } = await findSite(site);
+  const target = { orgSlug: server.org_slug, serverId: server.id, siteId: found.id, token };
+
+  let deployment = deploymentId;
+  if (!deployment) {
+    const [latest] = await Site.getDeploymentHistory(target);
+    if (!latest) return { site: found.name, log: "", note: "This site has no deployments yet." };
+    deployment = latest.id;
+  }
+
+  const log = await Site.getDeploymentOutput({ ...target, deploymentId: deployment });
+  return { site: found.name, deploymentId: deployment, log: tail(log) };
+}

--- a/src/tools/deployment-status.ts
+++ b/src/tools/deployment-status.ts
@@ -1,4 +1,4 @@
-import { allSites } from "../lib/resolve";
+import { allSites } from "./helpers";
 
 export default async function tool() {
   const sites = await allSites();

--- a/src/tools/deployment-status.ts
+++ b/src/tools/deployment-status.ts
@@ -1,0 +1,13 @@
+import { allSites } from "../lib/resolve";
+
+export default async function tool() {
+  const sites = await allSites();
+  return {
+    deploying: sites
+      .filter(({ site }) => site.deployment_status === "deploying")
+      .map(({ site, server }) => ({ site: site.name, server: server.name })),
+    failed: sites
+      .filter(({ site }) => site.deployment_status === "failed")
+      .map(({ site, server }) => ({ site: site.name, server: server.name })),
+  };
+}

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -6,29 +6,14 @@ import { unwrapToken } from "../lib/auth";
 export type ServerMatch = { server: IServer; token: string };
 export type SiteMatch = { site: ISite; server: IServer; token: string };
 
-type Candidate<T> = { entry: T; label: string; score: number };
-
 const normalize = (value: string) => value.trim().toLowerCase();
 
-const score = (name: string | undefined, query: string) => {
-  const target = normalize(name ?? "");
-  const search = normalize(query);
-  if (!target || !search) return 0;
-  if (target === search) return 2;
-  return target.includes(search) ? 1 : 0;
-};
-
 // Errors instead of a best guess, so the model re-asks rather than hitting the wrong server
-const pick = <T>(candidates: Candidate<T>[], query: string, kind: string) => {
-  const best = Math.max(0, ...candidates.map((candidate) => candidate.score));
-  const labels = candidates.map((candidate) => candidate.label).join(", ");
-  if (!best) throw new Error(`No ${kind} matches "${query}". Available ${kind}s: ${labels}`);
-  const winners = candidates.filter((candidate) => candidate.score === best);
-  if (winners.length > 1) {
-    throw new Error(`"${query}" matches several ${kind}s: ${winners.map((w) => w.label).join(", ")}. Ask which one.`);
-  }
-  return winners[0].entry;
-};
+const noMatch = (kind: string, query: string, names: string[]) =>
+  new Error(`No ${kind} matches "${query}". Available ${kind}s: ${names.join(", ")}`);
+
+const ambiguous = (kind: string, query: string, names: string[]) =>
+  new Error(`"${query}" matches several ${kind}s: ${names.join(", ")}. Ask which one.`);
 
 export const allServers = async (): Promise<ServerMatch[]> => {
   const servers = await Server.getAll();
@@ -37,15 +22,15 @@ export const allServers = async (): Promise<ServerMatch[]> => {
 
 export const findServer = async (query: string) => {
   const servers = await allServers();
-  return pick(
-    servers.map((entry) => ({
-      entry,
-      label: entry.server.name ?? String(entry.server.id),
-      score: Math.max(score(entry.server.name, query), String(entry.server.id) === normalize(query) ? 2 : 0),
-    })),
-    query,
-    "server",
-  );
+  const search = normalize(query);
+  const label = ({ server }: ServerMatch) => server.name ?? String(server.id);
+
+  const exact = servers.filter(({ server }) => normalize(server.name ?? "") === search || String(server.id) === search);
+  const found = exact.length ? exact : servers.filter(({ server }) => normalize(server.name ?? "").includes(search));
+
+  if (!found.length) throw noMatch("server", query, servers.map(label));
+  if (found.length > 1) throw ambiguous("server", query, found.map(label));
+  return found[0];
 };
 
 export const allSites = async (): Promise<SiteMatch[]> => {
@@ -67,19 +52,16 @@ export const allSites = async (): Promise<SiteMatch[]> => {
 
 export const findSite = async (query: string) => {
   const sites = await allSites();
-  return pick(
-    sites.map((entry) => ({
-      entry,
-      label: entry.site.name ?? String(entry.site.id),
-      score: Math.max(
-        score(entry.site.name, query),
-        String(entry.site.id) === normalize(query) ? 2 : 0,
-        ...(entry.site.aliases ?? []).map((alias) => score(alias, query)),
-      ),
-    })),
-    query,
-    "site",
-  );
+  const search = normalize(query);
+  const label = ({ site }: SiteMatch) => site.name ?? String(site.id);
+  const names = ({ site }: SiteMatch) => [site.name ?? "", ...(site.aliases ?? [])].map(normalize);
+
+  const exact = sites.filter((match) => names(match).includes(search) || String(match.site.id) === search);
+  const found = exact.length ? exact : sites.filter((match) => names(match).some((name) => name.includes(search)));
+
+  if (!found.length) throw noMatch("site", query, sites.map(label));
+  if (found.length > 1) throw ambiguous("site", query, found.map(label));
+  return found[0];
 };
 
 // Logs run to megabytes and the whole result is fed to the model

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -1,7 +1,7 @@
 import { Server } from "../api/Server";
 import { Site } from "../api/Site";
 import { IServer, ISite } from "../types";
-import { unwrapToken } from "./auth";
+import { unwrapToken } from "../lib/auth";
 
 export type ServerMatch = { server: IServer; token: string };
 export type SiteMatch = { site: ISite; server: IServer; token: string };

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -64,6 +64,19 @@ export const findSite = async (query: string) => {
   return found[0];
 };
 
+export const sitesOnServer = async (server: IServer) => {
+  const sites = await allSites();
+  return sites
+    .filter((match) => match.server.id === server.id && match.server.api_token_key === server.api_token_key)
+    .map(({ site }) => site.name ?? String(site.id));
+};
+
+export const nameList = (names: string[], limit = 8) => {
+  if (!names.length) return "none";
+  if (names.length <= limit) return names.join(", ");
+  return `${names.slice(0, limit).join(", ")} and ${names.length - limit} more`;
+};
+
 // Logs run to megabytes and the whole result is fed to the model
 export const tail = (output: string, limit = 4_000) =>
   output.length > limit ? `…truncated…\n${output.slice(-limit)}` : output;

--- a/src/tools/list-servers.ts
+++ b/src/tools/list-servers.ts
@@ -1,0 +1,16 @@
+import { allServers } from "../lib/resolve";
+
+export default async function tool() {
+  const servers = await allServers();
+  return servers.map(({ server }) => ({
+    id: server.id,
+    name: server.name,
+    provider: server.provider,
+    region: server.region,
+    ipAddress: server.ip_address,
+    phpVersion: server.php_version,
+    databaseType: server.database_type,
+    connectionStatus: server.connection_status,
+    isReady: server.is_ready,
+  }));
+}

--- a/src/tools/list-servers.ts
+++ b/src/tools/list-servers.ts
@@ -1,4 +1,4 @@
-import { allServers } from "../lib/resolve";
+import { allServers } from "./helpers";
 
 export default async function tool() {
   const servers = await allServers();

--- a/src/tools/list-sites.ts
+++ b/src/tools/list-sites.ts
@@ -1,0 +1,27 @@
+import { allSites } from "../lib/resolve";
+
+type Input = {
+  /**
+   * Name of a server to limit the list to. Leave empty to list sites across every server and account.
+   */
+  server?: string;
+};
+
+export default async function tool({ server }: Input) {
+  const sites = await allSites();
+  const wanted = server?.trim().toLowerCase();
+  return sites
+    .filter((match) => !wanted || (match.server.name ?? "").toLowerCase().includes(wanted))
+    .map(({ site, server: owner }) => ({
+      id: site.id,
+      name: site.name,
+      server: owner.name,
+      url: site.url,
+      phpVersion: site.php_version,
+      status: site.status,
+      deploymentStatus: site.deployment_status,
+      repository: site.repository?.url,
+      branch: site.repository?.branch,
+      quickDeploy: site.quick_deploy,
+    }));
+}

--- a/src/tools/list-sites.ts
+++ b/src/tools/list-sites.ts
@@ -1,4 +1,4 @@
-import { allSites } from "../lib/resolve";
+import { allSites } from "./helpers";
 
 type Input = {
   /**

--- a/src/tools/reboot-server.ts
+++ b/src/tools/reboot-server.ts
@@ -1,6 +1,6 @@
 import { Tool } from "@raycast/api";
 import { Server } from "../api/Server";
-import { findServer } from "./helpers";
+import { findServer, nameList, sitesOnServer } from "./helpers";
 
 type Input = {
   /**
@@ -11,9 +11,14 @@ type Input = {
 
 export const confirmation: Tool.Confirmation<Input> = async ({ server }) => {
   const { server: found } = await findServer(server);
+  const sites = await sitesOnServer(found);
   return {
     message: `Reboot ${found.name}? Every site on it goes down until it comes back.`,
-    info: [{ name: "IP address", value: found.ip_address ?? "unknown" }],
+    info: [
+      { name: `Sites going down (${sites.length})`, value: nameList(sites) },
+      { name: "Provider", value: [found.provider, found.region].filter(Boolean).join(" · ") || "unknown" },
+      { name: "IP address", value: found.ip_address ?? "unknown" },
+    ],
   };
 };
 

--- a/src/tools/reboot-server.ts
+++ b/src/tools/reboot-server.ts
@@ -1,6 +1,6 @@
 import { Tool } from "@raycast/api";
 import { Server } from "../api/Server";
-import { findServer } from "../lib/resolve";
+import { findServer } from "./helpers";
 
 type Input = {
   /**

--- a/src/tools/reboot-server.ts
+++ b/src/tools/reboot-server.ts
@@ -1,0 +1,24 @@
+import { Tool } from "@raycast/api";
+import { Server } from "../api/Server";
+import { findServer } from "../lib/resolve";
+
+type Input = {
+  /**
+   * Name of the server to reboot, as shown in Forge.
+   */
+  server: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async ({ server }) => {
+  const { server: found } = await findServer(server);
+  return {
+    message: `Reboot ${found.name}? Every site on it goes down until it comes back.`,
+    info: [{ name: "IP address", value: found.ip_address ?? "unknown" }],
+  };
+};
+
+export default async function tool({ server }: Input) {
+  const { server: found, token } = await findServer(server);
+  await Server.runAction({ server: found, token, action: "reboot" });
+  return { server: found.name, action: "reboot", started: true };
+}

--- a/src/tools/restart-service.ts
+++ b/src/tools/restart-service.ts
@@ -1,6 +1,6 @@
 import { Tool } from "@raycast/api";
 import { Server, ServiceAction } from "../api/Server";
-import { findServer } from "./helpers";
+import { findServer, nameList, sitesOnServer } from "./helpers";
 
 type Input = {
   /**
@@ -19,9 +19,14 @@ type Input = {
 
 export const confirmation: Tool.Confirmation<Input> = async ({ server, service, action = "reboot" }) => {
   const { server: found } = await findServer(server);
+  const sites = await sitesOnServer(found);
   return {
     message: `${action === "reboot" ? "Restart" : action} ${service} on ${found.name}?`,
-    info: [{ name: "Sites affected", value: "every site on this server" }],
+    info: [
+      { name: `Sites affected (${sites.length})`, value: nameList(sites) },
+      { name: "Server", value: found.name ?? String(found.id) },
+      ...(service === "php" ? [{ name: "PHP version", value: found.php_version ?? "unknown" }] : []),
+    ],
   };
 };
 

--- a/src/tools/restart-service.ts
+++ b/src/tools/restart-service.ts
@@ -1,0 +1,32 @@
+import { Tool } from "@raycast/api";
+import { Server, ServiceAction } from "../api/Server";
+import { findServer } from "../lib/resolve";
+
+type Input = {
+  /**
+   * Name of the server, as shown in Forge.
+   */
+  server: string;
+  /**
+   * Which service to act on.
+   */
+  service: "php" | "nginx" | "mysql" | "redis";
+  /**
+   * What to do with the service. Defaults to a restart.
+   */
+  action?: ServiceAction;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async ({ server, service, action = "reboot" }) => {
+  const { server: found } = await findServer(server);
+  return {
+    message: `${action === "reboot" ? "Restart" : action} ${service} on ${found.name}?`,
+    info: [{ name: "Sites affected", value: "every site on this server" }],
+  };
+};
+
+export default async function tool({ server, service, action = "reboot" }: Input) {
+  const { server: found, token } = await findServer(server);
+  await Server.runAction({ server: found, token, action, service });
+  return { server: found.name, service, action, started: true };
+}

--- a/src/tools/restart-service.ts
+++ b/src/tools/restart-service.ts
@@ -1,6 +1,6 @@
 import { Tool } from "@raycast/api";
 import { Server, ServiceAction } from "../api/Server";
-import { findServer } from "../lib/resolve";
+import { findServer } from "./helpers";
 
 type Input = {
   /**

--- a/src/tools/server-events.ts
+++ b/src/tools/server-events.ts
@@ -1,0 +1,30 @@
+import { Server } from "../api/Server";
+import { findServer, tail } from "../lib/resolve";
+
+type Input = {
+  /**
+   * Name of the server, as shown in Forge.
+   */
+  server: string;
+  /**
+   * Id of a specific event to read the command output of. Leave empty to list recent events.
+   */
+  eventId?: number;
+};
+
+export default async function tool({ server, eventId }: Input) {
+  const { server: found, token } = await findServer(server);
+
+  if (eventId) {
+    const output = await Server.getEventOutput({ server: found, token, eventId });
+    return { server: found.name, eventId, output: tail(output) };
+  }
+
+  const events = await Server.getEvents({ server: found, token });
+  return events.map((event) => ({
+    id: event.id,
+    description: event.description,
+    ranAs: event.ran_as,
+    createdAt: event.created_at,
+  }));
+}

--- a/src/tools/server-events.ts
+++ b/src/tools/server-events.ts
@@ -1,5 +1,5 @@
 import { Server } from "../api/Server";
-import { findServer, tail } from "../lib/resolve";
+import { findServer, tail } from "./helpers";
 
 type Input = {
   /**

--- a/src/tools/site-config.ts
+++ b/src/tools/site-config.ts
@@ -1,5 +1,5 @@
 import { Site } from "../api/Site";
-import { findSite, tail } from "../lib/resolve";
+import { findSite, tail } from "./helpers";
 
 type Input = {
   /**

--- a/src/tools/site-config.ts
+++ b/src/tools/site-config.ts
@@ -1,0 +1,26 @@
+import { Site } from "../api/Site";
+import { findSite, tail } from "../lib/resolve";
+
+type Input = {
+  /**
+   * Name of the site, as shown in Forge (for example "example.com").
+   */
+  site: string;
+  // env is left out: it holds secrets the model would receive
+  /**
+   * Which file to read.
+   */
+  type: "nginx" | "application-log" | "nginx-error-log" | "nginx-access-log";
+};
+
+export default async function tool({ site, type }: Input) {
+  const { site: found, server, token } = await findSite(site);
+  const content = await Site.getConfig({
+    orgSlug: server.org_slug,
+    serverId: server.id,
+    siteId: found.id,
+    token,
+    type,
+  });
+  return { site: found.name, type, content: tail(content) };
+}

--- a/src/tools/site-online.ts
+++ b/src/tools/site-online.ts
@@ -1,4 +1,4 @@
-import { findSite } from "../lib/resolve";
+import { findSite } from "./helpers";
 import { findValidUrlsFromSite } from "../lib/url";
 
 type Input = {

--- a/src/tools/site-online.ts
+++ b/src/tools/site-online.ts
@@ -1,0 +1,20 @@
+import { findSite } from "../lib/resolve";
+import { findValidUrlsFromSite } from "../lib/url";
+
+type Input = {
+  /**
+   * Name of the site, as shown in Forge (for example "example.com").
+   */
+  site: string;
+};
+
+export default async function tool({ site }: Input) {
+  const { site: found } = await findSite(site);
+  const urls = findValidUrlsFromSite(found);
+  try {
+    const res = await Promise.any(urls.map((url) => fetch(`http://${url}`, { method: "HEAD" })));
+    return { site: found.name, online: true, url: res.url, status: res.status };
+  } catch {
+    return { site: found.name, online: false, checked: urls };
+  }
+}


### PR DESCRIPTION
Turns the extension into an AI Extension: eleven tools over the same `Server`/`Site` API layer the commands already use, so AI Chat can answer "what's deploying", read the log of a failed deploy, or trigger a deploy without opening a command. Raycast adds an "Ask Laravel Forge" item to root search on its own once tools exist.

Read tools: `list-servers`, `list-sites`, `deployment-status`, `deployment-history`, `deployment-log`, `server-events`, `site-online`, `site-config`.

Write tools, each exporting a `Tool.Confirmation` that names what it will affect — the reboot and service cards list the sites going down, deploy shows repository, branch and current status: `deploy-site`, `restart-service`, `reboot-server`.

A few decisions worth a second opinion:

- A name that matches nothing, or more than one thing, comes back as an error listing the real names, so the model re-asks instead of deploying `example.com` when you meant `staging.example.com`.
- Logs and configs are tail-capped at 4k characters; a full deploy log would otherwise fill the model's context.
- `site-config` has no `env` option. Tool output is sent to the model and that file holds secrets.
- Sites are matched to servers per token, since server ids are only unique within one account.
- The `php`/`nginx`/`mysql`/`redis` slugs in `restart-service` are an assumption about the v2 `services/{service}/actions` endpoint — nothing else in the extension exercises that path, so it needs a live try.

Also in here: the API token preference lost its migration-note tooltip, `node-fetch` is gone in favour of the runtime's global `fetch`, and API failures now report through `captureException` instead of only a toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)