### PR TITLE
Cut the Forge requests each AI answer makes

### DIFF
--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -1,10 +1,102 @@
-import { Server } from "../api/Server";
-import { Site } from "../api/Site";
-import { IServer, ISite } from "../types";
+import { getPreferenceValues } from "@raycast/api";
+import { sortBy } from "lodash";
 import { unwrapToken } from "../lib/auth";
+import { flatten, getCollection, relatedId, relatedResource } from "../lib/forge";
+import { IServer, ISite } from "../types";
 
 export type ServerMatch = { server: IServer; token: string };
 export type SiteMatch = { site: ISite; server: IServer; token: string };
+
+type Account = { tokenKey: string; token: string; sshUser: string };
+
+// One fetch serves a whole answer: a confirmation and its tool, or two tools the model chains
+const once = <T>(build: () => Promise<T>) => {
+  let pending: Promise<T> | undefined;
+  return () => (pending ??= build());
+};
+
+const accounts = (): Account[] => {
+  const preferences = getPreferenceValues();
+  return [
+    { tokenKey: "laravel_forge_api_token", sshUser: String(preferences?.laravel_forge_ssh_user || "forge") },
+    { tokenKey: "laravel_forge_api_token_two", sshUser: String(preferences?.laravel_forge_ssh_user_two || "forge") },
+  ]
+    .map((account) => ({ ...account, token: unwrapToken(account.tokenKey) }))
+    .filter((account) => account.token);
+};
+
+const orgSlugs = once(async () => {
+  const entries = await Promise.all(
+    accounts().map(async ({ tokenKey, token }) => {
+      const { items } = await getCollection("orgs", token);
+      return [tokenKey, items.map((org) => String(org.attributes?.slug ?? ""))] as const;
+    }),
+  );
+  return new Map(entries);
+});
+
+export const allServers = once(async (): Promise<ServerMatch[]> => {
+  const slugs = await orgSlugs();
+  const perAccount = await Promise.all(
+    accounts().map(async ({ tokenKey, token, sshUser }) => {
+      const perOrg = await Promise.all(
+        (slugs.get(tokenKey) ?? []).map(async (slug) => {
+          const { items } = await getCollection(`orgs/${slug}/servers`, token);
+          return items.map((server) => ({
+            server: { ...flatten<IServer>(server), org_slug: slug, api_token_key: tokenKey, ssh_user: sshUser },
+            token,
+          }));
+        }),
+      );
+      return perOrg.flat();
+    }),
+  );
+  return sortBy(
+    perAccount.flat().filter(({ server }) => !server.revoked),
+    ({ server }) => server.name?.toLowerCase(),
+  );
+});
+
+const orgByServerId = async (tokenKey: string) => {
+  const servers = await allServers();
+  return new Map(
+    servers.filter(({ server }) => server.api_token_key === tokenKey).map(({ server }) => [server.id, server.org_slug]),
+  );
+};
+
+export const allSites = once(async (): Promise<SiteMatch[]> => {
+  const slugs = await orgSlugs();
+  const perAccount = await Promise.all(
+    accounts().map(async ({ tokenKey, token, sshUser }) => {
+      const { items, included } = await getCollection("sites?include=server", token);
+      const orgs = slugs.get(tokenKey) ?? [];
+      // The site list carries its server; only the org slug needs the server walk
+      const owners = orgs.length > 1 ? await orgByServerId(tokenKey) : undefined;
+
+      return items.flatMap((item) => {
+        const resource = relatedResource(item, "server", included);
+        if (!resource) return [];
+        const id = Number(resource.id);
+        const server: IServer = {
+          ...flatten<IServer>(resource),
+          org_slug: owners ? (owners.get(id) ?? "") : (orgs[0] ?? ""),
+          api_token_key: tokenKey,
+          ssh_user: sshUser,
+        };
+        const site = { ...flatten<ISite>(item), server_id: relatedId(item, "server") ?? id };
+        return [{ site, server, token }];
+      });
+    }),
+  );
+  return sortBy(perAccount.flat(), ({ site }) => site.name?.toLowerCase());
+});
+
+export const sitesOnServer = async (server: IServer) => {
+  const sites = await allSites();
+  return sites
+    .filter((match) => match.server.id === server.id && match.server.api_token_key === server.api_token_key)
+    .map(({ site }) => site.name ?? String(site.id));
+};
 
 const normalize = (value: string) => value.trim().toLowerCase();
 
@@ -14,11 +106,6 @@ const noMatch = (kind: string, query: string, names: string[]) =>
 
 const ambiguous = (kind: string, query: string, names: string[]) =>
   new Error(`"${query}" matches several ${kind}s: ${names.join(", ")}. Ask which one.`);
-
-export const allServers = async (): Promise<ServerMatch[]> => {
-  const servers = await Server.getAll();
-  return servers.map((server) => ({ server, token: unwrapToken(server.api_token_key) }));
-};
 
 export const findServer = async (query: string) => {
   const servers = await allServers();
@@ -33,23 +120,6 @@ export const findServer = async (query: string) => {
   return found[0];
 };
 
-export const allSites = async (): Promise<SiteMatch[]> => {
-  const servers = await allServers();
-  const tokenKeys = [...new Set(servers.map(({ server }) => server.api_token_key))];
-  const perAccount = await Promise.all(
-    tokenKeys.map(async (tokenKey) => {
-      const token = unwrapToken(tokenKey);
-      const sites = await Site.getSitesWithoutServer({ token });
-      return sites.flatMap((site) => {
-        // Server ids only mean anything within the account they came from
-        const owner = servers.find(({ server }) => server.api_token_key === tokenKey && server.id === site.server_id);
-        return owner ? [{ site, server: owner.server, token }] : [];
-      });
-    }),
-  );
-  return perAccount.flat();
-};
-
 export const findSite = async (query: string) => {
   const sites = await allSites();
   const search = normalize(query);
@@ -62,13 +132,6 @@ export const findSite = async (query: string) => {
   if (!found.length) throw noMatch("site", query, sites.map(label));
   if (found.length > 1) throw ambiguous("site", query, found.map(label));
   return found[0];
-};
-
-export const sitesOnServer = async (server: IServer) => {
-  const sites = await allSites();
-  return sites
-    .filter((match) => match.server.id === server.id && match.server.api_token_key === server.api_token_key)
-    .map(({ site }) => site.name ?? String(site.id));
 };
 
 export const nameList = (names: string[], limit = 8) => {


### PR DESCRIPTION
The tools were expensive enough to draw a `429` out of Forge. Every site tool resolved names through `Server.getAll`, which walks `orgs`, then `servers` per org, then fetches the entire site list a second time to build search keywords no tool reads — and a confirmation plus its tool each did that walk independently. `sites?include=server` already returns each site with its server attached; the old code asked for that include and then threw the server away, keeping only the numeric id.

Site tools now read that flat list and keep the included server. The org slug per-site endpoints need is the one thing the list can't supply, and with a single organization every server belongs to it, so only a multi-org account still pays for the server walk. Both indexes are built once per process, so a confirmation, its tool, and a second chained tool share one fetch.

Requests on a single-org account with one token:

| | before | after |
| --- | --- | --- |
| `list-servers` | 3 | 2 |
| `deployment-status` | 4 | 2 |
| `deployment-log` | 6 | 4 |
| `deploy-site` | 9 | 3 |
| `reboot-server` | 11 | 4 |
| "why did the deploy fail?" (two tools) | 10 | 4 |

Server-targeting tools keep the `orgs` + `servers` walk, since a server with no sites never appears in the site list. Output is sorted by name in both indexes, which the old path got from `sortAndFilterSites`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)