### PR TITLE
Route common questions to the right tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     }
   ],
   "ai": {
-    "instructions": "Deployments belong to sites, not servers. To explain a failed deploy, call deployment-status first to learn which site failed, then deployment-log for that site. If no site is currently marked failed, call deployment-history for the site in question and pass the id of the most recent failed deployment to deployment-log. Server-level trouble - provisioning, a service that will not come back - is in server-events, not in a deployment log. Site names are domains, and a site also answers on its aliases. Never guess a name: when a tool returns an error listing the available servers or sites, ask the user which one they meant. Only deploy a site, restart a service or reboot a server when the user asks for that action."
+    "instructions": "Deployments belong to sites, not servers.\nFailed deploy: deployment-status names the failing site, then deployment-log. If nothing is marked failed, take the id from deployment-history.\nSite down or erroring: site-online, then site-config for nginx-error-log, then application-log.\nServer trouble, like provisioning or a service that will not start: server-events.\nWhich server, PHP version, repository or branch a site uses: list-sites.\nA site's env file is not available here.\nSite names are domains and also answer on their aliases. If a lookup returns several names, ask which one.\nOnly deploy, restart or reboot when asked. Quick deploy being off means Forge will not deploy on push by itself."
   },
   "tools": [
     {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
       "interval": "10s"
     }
   ],
+  "ai": {
+    "instructions": "Deployments belong to sites, not servers. To explain a failed deploy, call deployment-status first to learn which site failed, then deployment-log for that site. If no site is currently marked failed, call deployment-history for the site in question and pass the id of the most recent failed deployment to deployment-log. Server-level trouble - provisioning, a service that will not come back - is in server-events, not in a deployment log. Site names are domains, and a site also answers on its aliases. Never guess a name: when a tool returns an error listing the available servers or sites, ask the user which one they meant. Only deploy a site, restart a service or reboot a server when the user asks for that action."
+  },
   "tools": [
     {
       "name": "list-servers",
@@ -52,12 +55,12 @@
     {
       "name": "deployment-status",
       "title": "Check Deployment Status",
-      "description": "Show which sites are deploying right now and which ones have a failed deployment"
+      "description": "Show which sites are deploying right now and which ones have a failed deployment. Start here to work out which site a question about a failed deploy is about"
     },
     {
       "name": "deployment-history",
       "title": "Get Deployment History",
-      "description": "List recent deployments for a site with their status, commit and timings"
+      "description": "List recent deployments for a site with their status, commit and timings. Use it to find an earlier failed deployment once the current status is no longer failed"
     },
     {
       "name": "deployment-log",

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -134,6 +134,15 @@ export const findSite = async (query: string) => {
   return found[0];
 };
 
+export const targetServer = async ({ server, site }: { server?: string; site?: string }): Promise<ServerMatch> => {
+  if (server) return findServer(server);
+  if (site) {
+    const match = await findSite(site);
+    return { server: match.server, token: match.token };
+  }
+  throw new Error("Name the server, or a site that runs on it.");
+};
+
 export const nameList = (names: string[], limit = 8) => {
   if (!names.length) return "none";
   if (names.length <= limit) return names.join(", ");

--- a/src/tools/reboot-server.ts
+++ b/src/tools/reboot-server.ts
@@ -1,16 +1,20 @@
 import { Tool } from "@raycast/api";
 import { Server } from "../api/Server";
-import { findServer, nameList, sitesOnServer } from "./helpers";
+import { nameList, sitesOnServer, targetServer } from "./helpers";
 
 type Input = {
   /**
-   * Name of the server to reboot, as shown in Forge.
+   * Name of the server to reboot, as shown in Forge. Leave empty if you only know a site that runs on it.
    */
-  server: string;
+  server?: string;
+  /**
+   * Name of a site on the server, used when the server itself was not named.
+   */
+  site?: string;
 };
 
-export const confirmation: Tool.Confirmation<Input> = async ({ server }) => {
-  const { server: found } = await findServer(server);
+export const confirmation: Tool.Confirmation<Input> = async ({ server, site }) => {
+  const { server: found } = await targetServer({ server, site });
   const sites = await sitesOnServer(found);
   return {
     message: `Reboot ${found.name}? Every site on it goes down until it comes back.`,
@@ -22,8 +26,8 @@ export const confirmation: Tool.Confirmation<Input> = async ({ server }) => {
   };
 };
 
-export default async function tool({ server }: Input) {
-  const { server: found, token } = await findServer(server);
+export default async function tool({ server, site }: Input) {
+  const { server: found, token } = await targetServer({ server, site });
   await Server.runAction({ server: found, token, action: "reboot" });
   return { server: found.name, action: "reboot", started: true };
 }

--- a/src/tools/restart-service.ts
+++ b/src/tools/restart-service.ts
@@ -1,12 +1,16 @@
 import { Tool } from "@raycast/api";
 import { Server, ServiceAction } from "../api/Server";
-import { findServer, nameList, sitesOnServer } from "./helpers";
+import { nameList, sitesOnServer, targetServer } from "./helpers";
 
 type Input = {
   /**
-   * Name of the server, as shown in Forge.
+   * Name of the server, as shown in Forge. Leave empty if you only know a site that runs on it.
    */
-  server: string;
+  server?: string;
+  /**
+   * Name of a site on the server, used when the server itself was not named.
+   */
+  site?: string;
   /**
    * Which service to act on.
    */
@@ -17,8 +21,8 @@ type Input = {
   action?: ServiceAction;
 };
 
-export const confirmation: Tool.Confirmation<Input> = async ({ server, service, action = "reboot" }) => {
-  const { server: found } = await findServer(server);
+export const confirmation: Tool.Confirmation<Input> = async ({ server, site, service, action = "reboot" }) => {
+  const { server: found } = await targetServer({ server, site });
   const sites = await sitesOnServer(found);
   return {
     message: `${action === "reboot" ? "Restart" : action} ${service} on ${found.name}?`,
@@ -30,8 +34,8 @@ export const confirmation: Tool.Confirmation<Input> = async ({ server, service, 
   };
 };
 
-export default async function tool({ server, service, action = "reboot" }: Input) {
-  const { server: found, token } = await findServer(server);
+export default async function tool({ server, site, service, action = "reboot" }: Input) {
+  const { server: found, token } = await targetServer({ server, site });
   await Server.runAction({ server: found, token, action, service });
   return { server: found.name, service, action, started: true };
 }

--- a/src/tools/site-online.ts
+++ b/src/tools/site-online.ts
@@ -13,7 +13,7 @@ export default async function tool({ site }: Input) {
   const urls = findValidUrlsFromSite(found);
   try {
     const res = await Promise.any(urls.map((url) => fetch(`http://${url}`, { method: "HEAD" })));
-    return { site: found.name, online: true, url: res.url, status: res.status };
+    return { site: found.name, online: res.status < 400, status: res.status, url: res.url };
   } catch {
     return { site: found.name, online: false, checked: urls };
   }


### PR DESCRIPTION
Asked "why did the deploy fail?", the model had nothing but eleven tool names to reason from, so it never worked out that a *site* has to be identified before a log can be read. `package.json` accepts an `ai.instructions` string that Raycast sends with the tool list, and this fills in what the names can't say. One short line per scenario — the text rides along with every request, so it stays terse:

- failed deploy → `deployment-status` for the site, then `deployment-log`; `deployment-history` when nothing is currently marked failed
- site down or erroring → `site-online`, then `nginx-error-log`, then `application-log`
- server that won't come back → `server-events`
- which server, PHP version, repository or branch → `list-sites`
- the env file isn't reachable from AI
- an ambiguous name is a question for the user
- never deploy, restart or reboot unasked; quick deploy being off means Forge won't deploy on push by itself

Two of those routes needed code:

- **"Restart php for example.com" names a site, not a server.** `restart-service` and `reboot-server` now take either and resolve a site to the box it runs on, instead of costing an extra lookup or failing when the names don't resemble each other.
- **`site-online` called any response at all online**, so a site throwing 502s read as up. It now returns the status code and counts 4xx and 5xx as unhealthy.

`ray lint` accepts the `ai` key in `package.json` (the manifest docs also mention an `ai.yaml`; this form validates and matches the evals docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)