### PR TITLE
Name Laravel Forge in every tool description

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,52 +50,52 @@
     {
       "name": "list-sites",
       "title": "List Sites",
-      "description": "List sites across every server, or only the sites on one named server, with their repository, branch and deployment status"
+      "description": "List the sites Laravel Forge manages, across every server or on one named server, with repository, branch and deployment status"
     },
     {
       "name": "deployment-status",
       "title": "Check Deployment Status",
-      "description": "Show which sites are deploying right now and which ones have a failed deployment. Start here to work out which site a question about a failed deploy is about"
+      "description": "Show which Laravel Forge sites are deploying right now and which ones have a failed deployment. Start here to work out which site a question about a failed deploy is about"
     },
     {
       "name": "deployment-history",
       "title": "Get Deployment History",
-      "description": "List recent deployments for a site with their status, commit and timings. Use it to find an earlier failed deployment once the current status is no longer failed"
+      "description": "List recent deployments of a Laravel Forge site with their status, commit and timings. Use it to find an earlier failed deployment once the current status is no longer failed"
     },
     {
       "name": "deployment-log",
       "title": "Read Deployment Log",
-      "description": "Read the output of a site's latest deployment, or of a specific deployment, to find out why it failed"
+      "description": "Read the output of a Laravel Forge site's latest deployment, or of a specific deployment, to find out why it failed"
     },
     {
       "name": "server-events",
       "title": "Get Server Events",
-      "description": "List recent Forge events for a server, or read the command output of one event"
+      "description": "List recent Laravel Forge events for a server, or read the command output of one event"
     },
     {
       "name": "site-online",
       "title": "Check If a Site Is Online",
-      "description": "Request a site over HTTP and report whether it responds"
+      "description": "Check whether a site hosted on Laravel Forge responds over HTTP, reporting the status code and treating a 4xx or 5xx as unhealthy"
     },
     {
       "name": "site-config",
       "title": "Read Site Config or Logs",
-      "description": "Read a site's nginx config, application log, nginx error log or nginx access log"
+      "description": "Read a Laravel Forge site's nginx config, application log, nginx error log or nginx access log"
     },
     {
       "name": "deploy-site",
       "title": "Deploy a Site",
-      "description": "Trigger a deployment for a site"
+      "description": "Run the deployment script for a Laravel Forge site, deploying the latest commit on its branch"
     },
     {
       "name": "restart-service",
       "title": "Restart a Service",
-      "description": "Start, stop or restart php, nginx, mysql or redis on a server"
+      "description": "Start, stop or restart php, nginx, mysql or redis on a Laravel Forge server, named directly or by a site running on it"
     },
     {
       "name": "reboot-server",
       "title": "Reboot a Server",
-      "description": "Reboot a server, taking every site on it down until it comes back"
+      "description": "Reboot a Laravel Forge server, named directly or by a site running on it, taking every site on it down until it comes back"
     }
   ],
   "preferences": [


### PR DESCRIPTION
Now that tools load without being asked for by name, a description is what makes the model reach for this extension instead of another one's tools — and only 2 of 11 said "Laravel Forge".

The three that would have lost a coin flip:

- **`site-online`** read as a generic URL checker ("Request a site over HTTP and report whether it responds"), so it would get pulled into any "is example.com up?" and then error, since it only accepts a Forge site name.
- **`deploy-site`** had the thinnest description of the lot — "Trigger a deployment for a site" — on the most consequential tool. It now says it runs the deployment script for the latest commit on the branch.
- **`list-sites`** gave no hint whose sites it lists, and most other questions route through it.

The rest gain the product name. `restart-service` and `reboot-server` also finally mention that they take a site as well as a server — those three edits were written in #32 and lost when the pre-commit hook rolled back the working tree, so the behaviour shipped without the descriptions catching up.

No code change; `ray lint` passes, including its Title Case check on tool titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
