### PR TITLE
Declare Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }


### PR DESCRIPTION
One line: `platforms` goes from `["macOS"]` to `["macOS", "Windows"]`. Nothing else changes.

- Menu bar commands aren't surfaced on Windows, so `check-deploy-status` and its AppleScript notification never run there. 13 of the top 100 store extensions declare both platforms while shipping a menu bar command — Linear, GitHub, Spotify Player, Todoist, Obsidian among them.
- Windows gets the servers and sites view, the deploy actions and all eleven AI tools; the deploy watcher stays a macOS feature.
- No hand-written keyboard shortcuts and no other node APIs in the extension, so `ray lint` and `ray build` pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)