### PR TITLE
Normalize deployment status for the AI tools too

### DIFF
--- a/src/api/Site.ts
+++ b/src/api/Site.ts
@@ -69,8 +69,10 @@ export const Site = {
 };
 
 // The API sends "Deploying" despite its documented lowercase status enums.
+export const deploymentStatus = (status?: string | null) => status?.toLowerCase() ?? null;
+
 export const sortAndFilterSites = (sites: ISite[]) =>
   sortBy(sites ?? [], "name").map((site) => ({
     ...site,
-    deployment_status: site.deployment_status?.toLowerCase() ?? null,
+    deployment_status: deploymentStatus(site.deployment_status),
   })) as ISite[];

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -1,5 +1,6 @@
 import { getPreferenceValues } from "@raycast/api";
 import { sortBy } from "lodash";
+import { deploymentStatus } from "../api/Site";
 import { unwrapToken } from "../lib/auth";
 import { flatten, getCollection, relatedId, relatedResource } from "../lib/forge";
 import { IServer, ISite } from "../types";
@@ -83,7 +84,12 @@ export const allSites = once(async (): Promise<SiteMatch[]> => {
           api_token_key: tokenKey,
           ssh_user: sshUser,
         };
-        const site = { ...flatten<ISite>(item), server_id: relatedId(item, "server") ?? id };
+        const flat = flatten<ISite>(item);
+        const site = {
+          ...flat,
+          server_id: relatedId(item, "server") ?? id,
+          deployment_status: deploymentStatus(flat.deployment_status),
+        };
         return [{ site, server, token }];
       });
     }),


### PR DESCRIPTION
The #34 fix landed in `sortAndFilterSites`, which only the UI hooks call. The tools build their sites straight from `flatten()` in `allSites`, so `deployment_status` stayed as the API sends it — `"Deploying"` — while `deployment-status.ts` compared against lowercase `"deploying"` and `"failed"`. Both filters never matched, so the tool answered "nothing deploying, nothing failed" whatever the account was actually doing, and that is what the model reported back.

- The lowercasing is a named export (`deploymentStatus`) applied in both places, so a third consumer inherits it instead of repeating the comparison.
- `deployment-status.ts` itself is unchanged.
- Not touched: `DeployHistory` and the `deployment-history` tool read a deployment record's own `status`, not the site's, and I haven't confirmed what case the API sends for those.
- `ray lint` and `ray build` pass on the v2 tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)