### PR TITLE
Never answer a site search with silent nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Services only offer the actions Forge accepts; there is no start
 - AI tools ask for an exact site or server name, or the id from list-sites, and suggest the closest matches otherwise
 - AI tools can no longer read env files or credentials, which hold secrets
+- Searching sites also matches aliases and server names, and a miss lists every site instead of answering with nothing
 
 ## [AI Tools] - 2026-08-20
 - Ask Laravel Forge from AI Chat: what is deploying, why a deploy failed, a site's Nginx config or logs, whether a site is up

--- a/src/tools/list-sites.ts
+++ b/src/tools/list-sites.ts
@@ -12,9 +12,24 @@ type Input = {
 };
 
 export default async function tool({ site, server }: Input) {
-  const sites = site ? await searchSites(site) : await allSites();
+  let sites = site ? await searchSites(site) : await allSites();
+  let note;
+  if (site && !sites.length) {
+    // Forge's filter only sees site names; the match may be in an alias or the server's name
+    const all = await allSites();
+    const query = site.trim().toLowerCase();
+    sites = all.filter(({ site: found, server: owner }) =>
+      [found.name, ...(found.aliases ?? []), owner.name]
+        .filter(Boolean)
+        .some((name) => String(name).toLowerCase().includes(query)),
+    );
+    if (!sites.length) {
+      sites = all;
+      note = `Nothing matches "${site}" by site name, alias or server name. Every site follows instead.`;
+    }
+  }
   const wanted = server?.trim().toLowerCase();
-  return sites
+  const listed = sites
     .filter(
       (match) =>
         !wanted || (match.server.name ?? "").toLowerCase().includes(wanted) || String(match.server.id) === wanted,
@@ -31,4 +46,5 @@ export default async function tool({ site, server }: Input) {
       branch: site.repository?.branch,
       quickDeploy: site.quick_deploy,
     }));
+  return note ? { note, sites: listed } : listed;
 }


### PR DESCRIPTION
Asked about "the cbp site", the model searched list-sites four ways, got an empty array each time, and gave up asking the user. The search was not broken: no site name contains cbp. The site is code-block-pro.com and cbp only appears in its server's name, which Forge's `filter[name]` never looks at — the model put the query in the `site` param instead of `server`, and a silent `[]` gave it nothing to pivot on.

A miss on Forge's filter now retries against everything the extension already has in hand — site names, aliases and server names, case-insensitive. If nothing matches at all, the tool returns every site under a note saying so: 41 names the model can scan beat an empty array it can only retry.

Verified live: `site: "cbp"` → code-block-pro.com, `site: "6-8"` still resolves by name first, a nonsense query returns the note plus all 41 sites, and the `server` filter still composes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)