### PR TITLE
Hand back a Forge page link, and point env at it

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,261 @@
     }
   ],
   "ai": {
-    "instructions": "Deployments belong to sites, not servers.\nFailed deploy: deployment-status names the site, then deployment-log. If nothing is marked failed, take the id from deployment-history.\nSite down or erroring: site-online, then site-config for nginx-error-log, then application-log.\nServer trouble, like provisioning or a service that will not start: server-events.\nWhich server, PHP version, repository or branch a site uses: list-sites.\nA site's env file is not available here.\nOnly deploy, restart or reboot when asked. Quick deploy off means Forge will not deploy on push by itself.\nLook a site or server up first and pass the id it returns, as a string: \"2882133\", never 2882133. Given a partial name, search for it with list-sites rather than asking the user which site they mean.\nThese tools return a short row on purpose. For any other Forge setting or field, call probe-api and read the attributes. Do not infer a setting from a config file, and do not say Forge does not know until you have probed."
+    "instructions": "Deployments belong to sites, not servers.\nFailed deploy: deployment-status names the site, then deployment-log. If nothing is marked failed, take the id from deployment-history.\nSite down or erroring: site-online, then site-config for nginx-error-log, then application-log.\nServer trouble, like provisioning or a service that will not start: server-events.\nOne site's full detail (zero-downtime, isolation, maintenance, repository, branch): get-site. One server's full detail and the sites on it: get-server. To find or list sites, or scan several at once: list-sites.\nA site's env file is not available here.\nOnly deploy, restart or reboot when asked. Quick deploy off means Forge will not deploy on push by itself.\nLook a site or server up first and pass the id it returns, as a string: \"2882133\", never 2882133. Given a partial name, search for it with list-sites rather than asking the user which site they mean.\nThese tools return a short row on purpose. For any other Forge setting or field, call probe-api and read the attributes. Do not infer a setting from a config file, and do not say Forge does not know until you have probed.",
+    "evals": [
+      {
+        "input": "@laravel-forge does the acme-store site have zero-downtime deploys enabled?",
+        "mocks": {
+          "list-sites": [
+            {
+              "id": 5001,
+              "name": "acme-store.com",
+              "server": "web-1",
+              "url": "https://acme-store.com",
+              "phpVersion": "PHP 8.3",
+              "status": "installed",
+              "deploymentStatus": "finished",
+              "repository": "acme/store",
+              "branch": "main",
+              "quickDeploy": true
+            },
+            {
+              "id": 5002,
+              "name": "acme-blog.com",
+              "server": "web-1",
+              "url": "https://acme-blog.com",
+              "phpVersion": "PHP 8.3",
+              "status": "installed",
+              "deploymentStatus": "finished",
+              "repository": "acme/store",
+              "branch": "main",
+              "quickDeploy": true
+            },
+            {
+              "id": 5003,
+              "name": "shop.example.test",
+              "server": "web-2",
+              "url": "https://shop.example.test",
+              "phpVersion": "PHP 8.3",
+              "status": "installed",
+              "deploymentStatus": "finished",
+              "repository": "acme/store",
+              "branch": "main",
+              "quickDeploy": true
+            }
+          ],
+          "get-site": {
+            "id": 5001,
+            "name": "acme-store.com",
+            "server": {
+              "id": 9001,
+              "name": "web-1"
+            },
+            "url": "https://acme-store.com",
+            "status": "installed",
+            "phpVersion": "PHP 8.3",
+            "zeroDowntimeDeployments": false,
+            "isolated": true,
+            "repository": {
+              "provider": "GitHub",
+              "url": "https://github.com/acme/store",
+              "branch": "main",
+              "status": "installed"
+            },
+            "quickDeploy": true,
+            "deploymentStatus": "finished"
+          }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "get-site",
+              "arguments": {
+                "site": {
+                  "includes": "acme-store"
+                }
+              }
+            }
+          },
+          {
+            "not": {
+              "callsTool": "probe-api"
+            }
+          }
+        ]
+      },
+      {
+        "input": "@laravel-forge what database engine does the web-2 server run?",
+        "mocks": {
+          "list-servers": [
+            {
+              "id": 9001,
+              "name": "web-1",
+              "provider": "ocean2",
+              "region": "nyc1",
+              "ipAddress": "10.0.0.1",
+              "phpVersion": "php83",
+              "databaseType": "mysql8",
+              "connectionStatus": "successful",
+              "isReady": true
+            },
+            {
+              "id": 9002,
+              "name": "web-2",
+              "provider": "ocean2",
+              "region": "nyc1",
+              "ipAddress": "10.0.0.2",
+              "phpVersion": "php84",
+              "databaseType": "postgres16",
+              "connectionStatus": "successful",
+              "isReady": true
+            }
+          ],
+          "get-server": {
+            "id": 9002,
+            "name": "web-2",
+            "provider": "ocean2",
+            "region": "nyc1",
+            "phpVersion": "php84",
+            "databaseType": "postgres16",
+            "connectionStatus": "successful",
+            "isReady": true,
+            "sites": [
+              "shop.example.test"
+            ]
+          }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "get-server",
+              "arguments": {
+                "server": {
+                  "includes": "web-2"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@laravel-forge restart the database on web-2",
+        "mocks": {
+          "list-servers": [
+            {
+              "id": 9001,
+              "name": "web-1",
+              "provider": "ocean2",
+              "region": "nyc1",
+              "ipAddress": "10.0.0.1",
+              "phpVersion": "php83",
+              "databaseType": "mysql8",
+              "connectionStatus": "successful",
+              "isReady": true
+            },
+            {
+              "id": 9002,
+              "name": "web-2",
+              "provider": "ocean2",
+              "region": "nyc1",
+              "ipAddress": "10.0.0.2",
+              "phpVersion": "php84",
+              "databaseType": "postgres16",
+              "connectionStatus": "successful",
+              "isReady": true
+            }
+          ],
+          "restart-service": {
+            "server": "web-2",
+            "service": "database",
+            "action": "reboot",
+            "started": true
+          }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "restart-service",
+              "arguments": {
+                "service": "database"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@laravel-forge is anything deploying right now?",
+        "mocks": {
+          "deployment-status": {
+            "deploying": [],
+            "failed": []
+          }
+        },
+        "expected": [
+          {
+            "callsTool": "deployment-status"
+          },
+          {
+            "not": {
+              "callsTool": "deploy-site"
+            }
+          }
+        ]
+      },
+      {
+        "input": "@laravel-forge deploy the acme-store site",
+        "mocks": {
+          "list-sites": [
+            {
+              "id": 5001,
+              "name": "acme-store.com",
+              "server": "web-1",
+              "url": "https://acme-store.com",
+              "phpVersion": "PHP 8.3",
+              "status": "installed",
+              "deploymentStatus": "finished",
+              "repository": "acme/store",
+              "branch": "main",
+              "quickDeploy": true
+            },
+            {
+              "id": 5002,
+              "name": "acme-blog.com",
+              "server": "web-1",
+              "url": "https://acme-blog.com",
+              "phpVersion": "PHP 8.3",
+              "status": "installed",
+              "deploymentStatus": "finished",
+              "repository": "acme/store",
+              "branch": "main",
+              "quickDeploy": true
+            },
+            {
+              "id": 5003,
+              "name": "shop.example.test",
+              "server": "web-2",
+              "url": "https://shop.example.test",
+              "phpVersion": "PHP 8.3",
+              "status": "installed",
+              "deploymentStatus": "finished",
+              "repository": "acme/store",
+              "branch": "main",
+              "quickDeploy": true
+            }
+          ],
+          "deploy-site": {
+            "site": "acme-store.com",
+            "server": "web-1",
+            "started": true
+          }
+        },
+        "expected": [
+          {
+            "callsTool": "deploy-site"
+          }
+        ]
+      }
+    ]
   },
   "tools": [
     {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     }
   ],
   "ai": {
-    "instructions": "Deployments belong to sites, not servers.\nFailed deploy: deployment-status names the site, then deployment-log. If nothing is marked failed, take the id from deployment-history.\nSite down or erroring: site-online, then site-config for nginx-error-log, then application-log.\nServer trouble, like provisioning or a service that will not start: server-events.\nOne site's full detail: get-site. One server's full detail and its sites: get-server. To find or list sites: list-sites.\nA site's env file is not available here.\nOnly deploy, restart or reboot when asked. Quick deploy off means Forge will not deploy on push by itself.\nLook a site or server up first and pass the id it returns, as a string: \"2882133\", never 2882133. Given a partial name, search for it with list-sites rather than asking the user which site they mean.\nlist-servers and list-sites return a short row on purpose. For one site's or one server's settings — zero-downtime, isolation, ubuntu version, and the like — call get-site or get-server, which return the full record. Only fall to probe-api for something even those do not return. Do not infer a setting from a config file, and do not say Forge does not know until you have probed.",
+    "instructions": "Deployments belong to sites, not servers.\nFailed deploy: deployment-status names the site, then deployment-log. If nothing is marked failed, take the id from deployment-history.\nSite down or erroring: site-online, then site-config for nginx-error-log, then application-log.\nServer trouble, like provisioning or a service that will not start: server-events.\nOne site's full detail: get-site. One server's full detail and its sites: get-server. To find or list sites: list-sites.\nA site's env file contents are not available here. When the user asks to see or edit it, call get-site and give them its environmentUrl to open in Forge.\nOnly deploy, restart or reboot when asked. Quick deploy off means Forge will not deploy on push by itself.\nLook a site or server up first and pass the id it returns, as a string: \"2882133\", never 2882133. Given a partial name, search for it with list-sites rather than asking the user which site they mean.\nlist-servers and list-sites return a short row on purpose. For one site's or one server's settings — zero-downtime, isolation, ubuntu version, and the like — call get-site or get-server, which return the full record. Only fall to probe-api for something even those do not return. Do not infer a setting from a config file, and do not say Forge does not know until you have probed.",
     "evals": [
       {
         "input": "@laravel-forge does acme-store have zero downtime deploys?",
@@ -292,6 +292,53 @@
         "expected": [
           {
             "callsTool": "deploy-site"
+          }
+        ]
+      },
+      {
+        "input": "@laravel-forge show me the env for acme-store",
+        "mocks": {
+          "list-sites": [
+            {
+              "id": 5001,
+              "name": "acme-store.com",
+              "server": "web-1",
+              "url": "https://acme-store.com",
+              "phpVersion": "PHP 8.3",
+              "status": "installed",
+              "deploymentStatus": "finished",
+              "repository": "acme/store",
+              "branch": "main",
+              "quickDeploy": true
+            }
+          ],
+          "get-site": {
+            "id": 5001,
+            "name": "acme-store.com",
+            "server": {
+              "id": 9001,
+              "name": "web-1"
+            },
+            "status": "installed",
+            "phpVersion": "PHP 8.3",
+            "zeroDowntimeDeployments": false,
+            "forgeUrl": "https://forge.laravel.com/acme-org/web-1/5001",
+            "environmentUrl": "https://forge.laravel.com/acme-org/web-1/5001/environment"
+          }
+        },
+        "expected": [
+          {
+            "callsTool": "get-site"
+          },
+          {
+            "not": {
+              "callsTool": "site-config"
+            }
+          },
+          {
+            "not": {
+              "callsTool": "probe-api"
+            }
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     }
   ],
   "ai": {
-    "instructions": "Deployments belong to sites, not servers.\nFailed deploy: deployment-status names the site, then deployment-log. If nothing is marked failed, take the id from deployment-history.\nSite down or erroring: site-online, then site-config for nginx-error-log, then application-log.\nServer trouble, like provisioning or a service that will not start: server-events.\nOne site's full detail (zero-downtime, isolation, maintenance, repository, branch): get-site. One server's full detail and the sites on it: get-server. To find or list sites, or scan several at once: list-sites.\nA site's env file is not available here.\nOnly deploy, restart or reboot when asked. Quick deploy off means Forge will not deploy on push by itself.\nLook a site or server up first and pass the id it returns, as a string: \"2882133\", never 2882133. Given a partial name, search for it with list-sites rather than asking the user which site they mean.\nThese tools return a short row on purpose. For any other Forge setting or field, call probe-api and read the attributes. Do not infer a setting from a config file, and do not say Forge does not know until you have probed.",
+    "instructions": "Deployments belong to sites, not servers.\nFailed deploy: deployment-status names the site, then deployment-log. If nothing is marked failed, take the id from deployment-history.\nSite down or erroring: site-online, then site-config for nginx-error-log, then application-log.\nServer trouble, like provisioning or a service that will not start: server-events.\nOne site's full detail: get-site. One server's full detail and its sites: get-server. To find or list sites: list-sites.\nA site's env file is not available here.\nOnly deploy, restart or reboot when asked. Quick deploy off means Forge will not deploy on push by itself.\nLook a site or server up first and pass the id it returns, as a string: \"2882133\", never 2882133. Given a partial name, search for it with list-sites rather than asking the user which site they mean.\nlist-servers and list-sites return a short row on purpose. For one site's or one server's settings — zero-downtime, isolation, ubuntu version, and the like — call get-site or get-server, which return the full record. Only fall to probe-api for something even those do not return. Do not infer a setting from a config file, and do not say Forge does not know until you have probed.",
     "evals": [
       {
-        "input": "@laravel-forge does the acme-store site have zero-downtime deploys enabled?",
+        "input": "@laravel-forge does acme-store have zero downtime deploys?",
         "mocks": {
           "list-sites": [
             {
@@ -102,18 +102,19 @@
             },
             "quickDeploy": true,
             "deploymentStatus": "finished"
+          },
+          "probe-api": {
+            "paths": [
+              "sites?filter[name]=acme-store"
+            ],
+            "onPage": 1,
+            "shown": 1,
+            "items": []
           }
         },
         "expected": [
           {
-            "callsTool": {
-              "name": "get-site",
-              "arguments": {
-                "site": {
-                  "includes": "acme-store"
-                }
-              }
-            }
+            "callsTool": "get-site"
           },
           {
             "not": {
@@ -123,7 +124,7 @@
         ]
       },
       {
-        "input": "@laravel-forge what database engine does the web-2 server run?",
+        "input": "@laravel-forge what ubuntu version is web-2 on?",
         "mocks": {
           "list-servers": [
             {
@@ -156,6 +157,7 @@
             "region": "nyc1",
             "phpVersion": "php84",
             "databaseType": "postgres16",
+            "ubuntuVersion": "22.04",
             "connectionStatus": "successful",
             "isReady": true,
             "sites": [
@@ -222,7 +224,7 @@
         ]
       },
       {
-        "input": "@laravel-forge is anything deploying right now?",
+        "input": "@laravel-forge anything deploying?",
         "mocks": {
           "deployment-status": {
             "deploying": [],
@@ -241,7 +243,7 @@
         ]
       },
       {
-        "input": "@laravel-forge deploy the acme-store site",
+        "input": "@laravel-forge deploy acme-store",
         "mocks": {
           "list-sites": [
             {

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,4 +1,4 @@
-import { IRepository, ISite } from "../types";
+import { IRepository, IServer, ISite } from "../types";
 
 export const repositoryLabel = (repository?: IRepository | null) =>
   repository?.url?.replace(/^https?:\/\/[^/]+\//, "") ?? "";
@@ -15,4 +15,15 @@ export const findValidUrlsFromSite = (site: ISite) => {
       }
     });
   return urls;
+};
+
+const FORGE_APP = "https://forge.laravel.com";
+
+// The dashboard path is org slug, then server slug, then site id — not the numeric server id
+export const forgeServerUrl = (server: IServer) =>
+  server.org_slug && server.slug ? `${FORGE_APP}/${server.org_slug}/${server.slug}` : undefined;
+
+export const forgeSiteUrl = (server: IServer, siteId: number) => {
+  const base = forgeServerUrl(server);
+  return base ? `${base}/${siteId}` : undefined;
 };

--- a/src/tools/get-server.ts
+++ b/src/tools/get-server.ts
@@ -1,3 +1,4 @@
+import { forgeServerUrl } from "../lib/url";
 import { findServer, sitesOnServer } from "./helpers";
 
 type Input = {
@@ -35,6 +36,7 @@ export default async function tool({ server }: Input) {
     revoked: found.revoked,
     createdAt: found.created_at,
     updatedAt: found.updated_at,
+    forgeUrl: forgeServerUrl(found),
     sites,
   };
 }

--- a/src/tools/get-site.ts
+++ b/src/tools/get-site.ts
@@ -1,3 +1,4 @@
+import { forgeSiteUrl } from "../lib/url";
 import { findSite, siteDeploymentStatus } from "./helpers";
 
 type Input = {
@@ -11,6 +12,7 @@ type Input = {
 export default async function tool({ site }: Input) {
   const { site: found, server } = await findSite(site);
   const deployment = found.latest_deployment;
+  const forgeUrl = forgeSiteUrl(server, found.id);
   return {
     id: found.id,
     name: found.name,
@@ -39,6 +41,9 @@ export default async function tool({ site }: Input) {
     healthcheckUrl: found.healthcheck_url,
     createdAt: found.created_at,
     updatedAt: found.updated_at,
+    forgeUrl,
+    // The file's contents are not returned; this is where a person edits them in Forge
+    environmentUrl: forgeUrl && `${forgeUrl}/environment`,
     latestDeployment: deployment && {
       id: deployment.id,
       status: deployment.status,


### PR DESCRIPTION
Stacked on #42 (evals).

`get-site` and `get-server` now return a `forgeUrl` (the site/server page in the Forge dashboard), and `get-site` adds an `environmentUrl`. The env file contents stay unavailable — but "show me the env" now gets a link to the page where you edit it, instead of a flat refusal.

The dashboard path is org-slug / server-**slug** / site-id — confirmed against the live UI (the numeric `servers/<id>/sites/<id>` form only redirects to sign-in). Site page is `/<org>/<server-slug>/<id>`; the env editor is that + `/environment`.

Instruction updated so the model answers a "show env" ask by handing over `environmentUrl`. Added a sixth eval for it — full suite passes 6/6 (ran `ray evals -t release`): the model calls `get-site` and returns the link without touching `site-config` or `probe-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)