### PR TITLE
Tell Forge who is calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Laravel Forge Changelog
 
+## [Improvements] - {PR_MERGE_DATE}
+
+- Name the extension in every request to Forge, so their support can trace calls this extension made
+
 ## [Fix] - 2026-08-29
 
 - Show active deployments in the menu bar again, including ones waiting at pending or failed during the build

--- a/src/lib/forge.ts
+++ b/src/lib/forge.ts
@@ -23,6 +23,7 @@ const headers = (token: string) => ({
   Accept: "application/json",
   "Content-Type": "application/json",
   Authorization: `Bearer ${token}`,
+  "User-Agent": "raycast-laravel-forge (+https://www.raycast.com/KevinBatdorf/laravel-forge)",
 });
 
 export const getCollection = async (path: string, token: string, { pages = PAGE_LIMIT, from = "" } = {}) => {


### PR DESCRIPTION
Every request went out with Node's default User-Agent of `node`, indistinguishable from any other script hitting the API. Forge documents no sender or attribution parameter — only Authorization, Accept and Content-Type — so the User-Agent is the one channel that reaches them. This sets it once in the shared headers helper, as `raycast-laravel-forge` plus the store listing URL.

- Forge support has something to grep when we ask about a 429 or a filter that 400s
- A named agent reads less like a bot to the WAF in front of the API than `node` does
- Opens a changelog section with the `{PR_MERGE_DATE}` placeholder, since the previous one is stamped and shipped
- The site-liveness HEAD pings hit the user's own sites rather than Forge, and are left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)